### PR TITLE
Fix Compilation Errors to get Tad Building Again.

### DIFF
--- a/src/database.cc
+++ b/src/database.cc
@@ -785,7 +785,7 @@ NAN_METHOD(Database::Import)
     OPTIONAL_ARGUMENT_FUNCTION(3, callback);
 
     Local<Array> colIdsJS = Local<Array>::Cast(
-        options->Get(context, String::NewFromUtf8(isolate, "columnIds").ToLocalChecked()).ToLocalChecked());
+        options->Get(context, String::NewFromUtf8(isolate, "columnIds", NewStringType::kNormal).ToLocalChecked()).ToLocalChecked());
 
     std::vector<std::string> colIds;
     int colCount = colIdsJS->Length();
@@ -798,9 +798,9 @@ NAN_METHOD(Database::Import)
 
     char delimChar = ',';
 
-    if (options->Has(context, String::NewFromUtf8(isolate, "delimiter").ToLocalChecked()).FromJust())
+    if (options->Has(context, String::NewFromUtf8(isolate, "delimiter", NewStringType::kNormal).ToLocalChecked()).FromJust())
     {
-        Nan::Utf8String delimNanStr(options->Get(context, String::NewFromUtf8(isolate, "delimiter").ToLocalChecked()).ToLocalChecked());
+        Nan::Utf8String delimNanStr(options->Get(context, String::NewFromUtf8(isolate, "delimiter", NewStringType::kNormal).ToLocalChecked()).ToLocalChecked());
         if (delimNanStr.length() != 1)
         {
             return Nan::ThrowError("options.delimeter must be a string of length 1");
@@ -809,10 +809,10 @@ NAN_METHOD(Database::Import)
     }
 
     bool noHeaderRow = false;
-    if (options->Has(context, String::NewFromUtf8(isolate, "noHeaderRow").ToLocalChecked()).FromJust())
+    if (options->Has(context, String::NewFromUtf8(isolate, "noHeaderRow", NewStringType::kNormal).ToLocalChecked()).FromJust())
     {
         Local<Value> noHeaderValue =
-            options->Get(context, String::NewFromUtf8(isolate, "noHeaderRow").ToLocalChecked()).ToLocalChecked();
+            options->Get(context, String::NewFromUtf8(isolate, "noHeaderRow", NewStringType::kNormal).ToLocalChecked()).ToLocalChecked();
         noHeaderRow = noHeaderValue->BooleanValue(isolate);
     }
 

--- a/src/database.cc
+++ b/src/database.cc
@@ -813,7 +813,7 @@ NAN_METHOD(Database::Import)
     {
         Local<Value> noHeaderValue =
             options->Get(context, String::NewFromUtf8(isolate, "noHeaderRow", NewStringType::kNormal).ToLocalChecked()).ToLocalChecked();
-        noHeaderRow = noHeaderValue->BooleanValue(isolate);
+        noHeaderRow = noHeaderValue->BooleanValue(context).FromJust();
     }
 
     ImportOptions importOptions(colIds, delimChar, noHeaderRow);


### PR DESCRIPTION
In the course of trying to get Tad to compile recently, I encountered problems getting this repo to build.
I was using the following configurations:

1. macOS High Sierra 10.13.6, node v12.18.3, clang Apple LLVM version 9.1.0 (clang-902.0.39.2)
2. macOS Catalina 10.15.5, node v12.18.3, clang Apple LLVM version 10.0.1 (clang-1001.0.46.4)

There were 5 errors similar to the following:
```
../src/database.cc:788:73: error: no member named 'ToLocalChecked' in 'v8::Local<v8::String>'
        options->Get(context, String::NewFromUtf8(isolate, "columnIds").ToLocalChecked()).ToLocalChecked());
                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^
```

It appears the the `NewFromUtf8` static member function comes in two flavors; one that returns a `Local<String>` and one that returns a `MaybeLocal<String>`. Explicitly specifying the `NewStringType` argument appears to force the compiler to choose the latter, given the use of `ToLocalChecked()` it appears the `MaybeLocal` one was intended.

I new to the whole node, npm, nan dependency hell, so apologies if this was not the correct edit. I hope this is useful.

While the above changes were sufficient to get this repo building in isolation, there was also a minor change to the way a boolean value was being extract needed to get Tad to build. 

If you accept this PR, I'll open one on the Tad repo that completes the fix.